### PR TITLE
Add AUR instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ $ cargo install stu
 $ brew install lusingander/tap/stu
 ```
 
+### AUR (Arch Linux)
+
+```
+$ paru -S stu
+```
+
 ## Usage
 
 ```


### PR DESCRIPTION
Hey! :bear:

I packaged `stu` for Arch Linux: <https://aur.archlinux.org/packages/stu>

This PR simply updates README.md to mention the package.

Cheers!
