### PR TITLE
feat: Expand environment variables in download directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3440,6 +3440,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3637,6 +3646,7 @@ dependencies = [
  "ratatui-image",
  "rstest",
  "serde",
+ "shellexpand",
  "smart-default",
  "syntect",
  "textwrap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ ratatui-image = "8.0.1"
 serde = { version = "1.0.219", features = ["derive"] }
 smart-default = "0.7.1"
 syntect = { version = "5.2.0", default-features = false, features = [
-  "default-fancy",
+    "default-fancy",
 ] }
 textwrap = "0.16.2"
 tokio = { version = "1.46.1", features = ["full"] }
@@ -52,6 +52,7 @@ tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.19", features = ["chrono"] }
 tui-input = "0.14.0"
 umbra = "0.4.0"
+shellexpand = "3.1"
 
 [dev-dependencies]
 rstest = "0.25.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,11 +106,35 @@ impl Config {
         let path = dir.join(CONFIG_FILE_NAME);
         if path.exists() {
             let content = std::fs::read_to_string(path)?;
-            let config: OptionalConfig = toml::from_str(&content)?;
+            let mut config: OptionalConfig = toml::from_str(&content)?;
+
+            if let Some(ref mut download_dir) = config.download_dir {
+                *download_dir = Self::expand_env_vars(download_dir)?;
+            }
             Ok(config.into())
         } else {
             Ok(Config::default())
         }
+    }
+
+    fn expand_env_vars(path: &str) -> anyhow::Result<String> {
+        let mut result = path.to_string();
+
+        while let Some(start) = result.find('$') {
+            let remaining = &result[start + 1..];
+            let end = remaining.find(|c: char| !c.is_alphanumeric() && c != '_')
+                .unwrap_or(remaining.len());
+
+            let var_name = &remaining[..end];
+            let var_value = match var_name {
+                "STU_ROOT_DIR" => Config::get_app_base_dir()?.to_string_lossy().to_string(),
+                _ => env::var(var_name).unwrap_or_else(|_| format!("${}", var_name)),
+            };
+
+            result.replace_range(start..start + 1 + end, &var_value);
+        }
+
+        Ok(result)
     }
 
     pub fn download_file_path<P: AsRef<Path>>(&self, name: P) -> PathBuf {


### PR DESCRIPTION
This commit adds the `shellexpand` crate as a dependency and expands environment variables in the download directory path. This allows users to specify paths relative to environment variables in their configuration.
