### PR TITLE
Add copying text in object preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ STU provides the following features:
 
 - Recursive object downloads
 - Previews with syntax highlighting for text files and inline rendering for images
-- Yank text content to clipboard from preview
 - Access to previous object versions
 - Customizable key bindings
 - Support for S3-compatible storage

--- a/assets/keybindings.toml
+++ b/assets/keybindings.toml
@@ -72,7 +72,7 @@ download_as = ["shift-s"]
 encoding = ["e"]
 toggle_wrap = ["w"]
 toggle_number = ["n"]
-yank = ["y"]
+copy = ["c"]
 
 [help]
 close = ["?", "backspace"]

--- a/docs/src/features/object-preview.md
+++ b/docs/src/features/object-preview.md
@@ -10,8 +10,7 @@
     - It must be enabled in the [config](../configurations/config-file-format.md#previewauto_detect_encoding)
 - Download object
   - Download a single selected object
-- Yank content to clipboard
-  - Press <kbd>y</kbd> to copy the text content to clipboard
+- Copy the text content to clipboard
 
 ![Object Preview](https://raw.githubusercontent.com/lusingander/stu/refs/heads/master/img/object-preview.png)
 ![Object Preview Image](https://raw.githubusercontent.com/lusingander/stu/refs/heads/master/img/object-preview-image.png)

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -68,7 +68,7 @@ pub enum UserEvent {
     ObjectPreviewEncoding,
     ObjectPreviewToggleWrap,
     ObjectPreviewToggleNumber,
-    ObjectPreviewYank,
+    ObjectPreviewCopy,
     HelpClose,
     InputDialogClose,
     InputDialogApply,
@@ -184,7 +184,7 @@ fn build_user_event_mapper(
     set_event_to_map(&mut map, &bindings, "object_preview", "encoding", UserEvent::ObjectPreviewEncoding)?;
     set_event_to_map(&mut map, &bindings, "object_preview", "toggle_wrap", UserEvent::ObjectPreviewToggleWrap)?;
     set_event_to_map(&mut map, &bindings, "object_preview", "toggle_number", UserEvent::ObjectPreviewToggleNumber)?;
-    set_event_to_map(&mut map, &bindings, "object_preview", "yank", UserEvent::ObjectPreviewYank)?;
+    set_event_to_map(&mut map, &bindings, "object_preview", "copy", UserEvent::ObjectPreviewCopy)?;
 
     set_event_to_map(&mut map, &bindings, "help", "close", UserEvent::HelpClose)?;
 


### PR DESCRIPTION
Adds the ability to yank text content from the preview window instead of having to download and cat to pbcopy or equivalent 